### PR TITLE
Constraint scanf check 

### DIFF
--- a/src/tinylisp-opt.c
+++ b/src/tinylisp-opt.c
@@ -93,7 +93,7 @@ L parse() {
  L n; I i;
  if (*buf == '(') return list();
  if (*buf == '\'') return cons(atom("quote"),cons(read(),nil));
- if (sscanf(buf,"%lg%n",&n,&i) && !buf[i]) return n;
+ if (sscanf(buf,"%lg%n",&n,&i) > 0 && !buf[i]) return n;
  return atom(buf);
 }
 void print(L);


### PR DESCRIPTION
>On success, the function returns the number of items in the argument list successfully filled. This count can match the expected number of items or be less (even zero) in the case of a matching failure.
>**In the case of an input failure before any data could be successfully interpreted, [EOF](https://cplusplus.com/EOF) is returned.**

Since negative values (more precisely non-zeroes) will be interpreted as true, this will in turn read garbage data and is undesired.