### PR TITLE
Add Missing Lambdas to cadr and caddr Definitions

### DIFF
--- a/src/common.lisp
+++ b/src/common.lisp
@@ -36,6 +36,6 @@
 (define >= (lambda (x y) (not (< x y))))
 (define = (lambda (x y) (eq? (- x y) 0)))
 (define list (lambda args args))
-(define cadr (car (cdr x)))
-(define caddr (car (cdr (cdr x))))
+(define cadr (lambda (x) (car (cdr x))))
+(define caddr (lambda (x) (car (cdr (cdr x)))))
 (define begin (lambda (x . args) (if args (begin . args) x)))


### PR DESCRIPTION
Hello, I'm working on my own version of this interpreter in Zig where I noticed this issue trying to load `common.lisp` with debug logging for an unrelated problem.