### PR TITLE
Fix for issue #17 (Interaction between dots in argument list and formal parameter list can cause some arguments to be evaluated more than once)

### DIFF
--- a/src/lisp850-opt.c
+++ b/src/lisp850-opt.c
@@ -69,11 +69,8 @@ L eval(L x,L e) {
   v = car(car(f)); d = cdr(f);
   if (T d == NIL) d = env;
   for (;T v == CONS && T x == CONS; v = cdr(v),x = cdr(x)) d = pair(car(v),eval(car(x),e),d);
-  if (T v == CONS) x = eval(x,e);
-  for (;T v == CONS; v = cdr(v),x = cdr(x)) d = pair(car(v),car(x),d);
-  if (T x == CONS) x = evlis(x,e);
-  else if (T x != NIL) x = eval(x,e);
-  if (T v != NIL) d = pair(v,x,d);
+  for (x = T x == CONS ? evlis(x,e) : eval(x,e); T v == CONS; v = cdr(v),x = cdr(x)) d = pair(car(v),car(x),d);
+  if (T v == ATOM) d = pair(v,x,d);
   x = cdr(car(f)); e = d;
  }
 }

--- a/src/tinylisp-float-opt.c
+++ b/src/tinylisp-float-opt.c
@@ -73,11 +73,8 @@ L eval(L x,L e) {
   v = car(car(f)); d = cdr(f);
   if (T(d) == NIL) d = env;
   for (;T(v) == CONS && T(x) == CONS; v = cdr(v),x = cdr(x)) d = pair(car(v),eval(car(x),e),d);
-  if (T(v) == CONS) x = eval(x,e);
-  for (;T(v) == CONS; v = cdr(v),x = cdr(x)) d = pair(car(v),car(x),d);
-  if (T(x) == CONS) x = evlis(x,e);
-  else if (T(x) != NIL) x = eval(x,e);
-  if (T(v) != NIL) d = pair(v,x,d);
+  for (x = T(x) == CONS ? evlis(x,e) : eval(x,e); T(v) == CONS; v = cdr(v),x = cdr(x)) d = pair(car(v),car(x),d);
+  if (T(v) == ATOM) d = pair(v,x,d);
   x = cdr(car(f)); e = d;
  }
 }

--- a/src/tinylisp-opt.c
+++ b/src/tinylisp-opt.c
@@ -7,19 +7,18 @@
 #define T(x) *(unsigned long long*)&x>>48
 #define A (char*)cell
 #define N 1024
-I hp=0,sp=N,lo=N,ATOM=0x7ff8,PRIM=0x7ff9,CONS=0x7ffa,CLOS=0x7ffb,NIL=0x7ffc;
+I hp=0,sp=N,ATOM=0x7ff8,PRIM=0x7ff9,CONS=0x7ffa,CLOS=0x7ffb,NIL=0x7ffc;
 L cell[N],nil,tru,err,env;
-void lwm() { if (sp-hp/8 < lo) lo = sp-hp/8; }
 L box(I t,I i) { L x; *(unsigned long long*)&x = (unsigned long long)t<<48|i; return x; }
 I ord(L x) { return *(unsigned long long*)&x; }
 L num(L n) { return n; }
 I equ(L x,L y) { return *(unsigned long long*)&x == *(unsigned long long*)&y; }
 L atom(const char *s) {
  I i = 0; while (i < hp && strcmp(A+i,s)) i += strlen(A+i)+1;
- if (i == hp && (hp += strlen(strcpy(A+i,s))+1) > sp<<3) abort(); lwm();
+ if (i == hp && (hp += strlen(strcpy(A+i,s))+1) > sp<<3) abort();
  return box(ATOM,i);
 }
-L cons(L x,L y) { cell[--sp] = x; cell[--sp] = y; if (hp > sp<<3) abort(); lwm(); return box(CONS,sp); }
+L cons(L x,L y) { cell[--sp] = x; cell[--sp] = y; if (hp > sp<<3) abort(); return box(CONS,sp); }
 L car(L p) { return (T(p)&~(CONS^CLOS)) == CONS ? cell[ord(p)+1] : err; }
 L cdr(L p) { return (T(p)&~(CONS^CLOS)) == CONS ? cell[ord(p)] : err; }
 L pair(L v,L x,L e) { return cons(cons(v,x),e); }
@@ -136,5 +135,5 @@ int main() {
  printf("tinylisp");
  nil = box(NIL,0); err = atom("ERR"); tru = atom("#t"); env = pair(tru,tru,nil);
  for (i = 0; prim[i].s; ++i) env = pair(atom(prim[i].s),box(PRIM,i),env);
- while (1) { printf("\n%u|%u>",sp-hp/8,lo); print(eval(Read(),env)); gc(); }
+ while (1) { printf("\n%u>",sp-hp/8); print(eval(Read(),env)); gc(); }
 }

--- a/src/tinylisp-opt.c
+++ b/src/tinylisp-opt.c
@@ -7,18 +7,19 @@
 #define T(x) *(unsigned long long*)&x>>48
 #define A (char*)cell
 #define N 1024
-I hp=0,sp=N,ATOM=0x7ff8,PRIM=0x7ff9,CONS=0x7ffa,CLOS=0x7ffb,NIL=0x7ffc;
+I hp=0,sp=N,lo=N,ATOM=0x7ff8,PRIM=0x7ff9,CONS=0x7ffa,CLOS=0x7ffb,NIL=0x7ffc;
 L cell[N],nil,tru,err,env;
+void lwm() { if (sp-hp/8 < lo) lo = sp-hp/8; }
 L box(I t,I i) { L x; *(unsigned long long*)&x = (unsigned long long)t<<48|i; return x; }
 I ord(L x) { return *(unsigned long long*)&x; }
 L num(L n) { return n; }
 I equ(L x,L y) { return *(unsigned long long*)&x == *(unsigned long long*)&y; }
 L atom(const char *s) {
  I i = 0; while (i < hp && strcmp(A+i,s)) i += strlen(A+i)+1;
- if (i == hp && (hp += strlen(strcpy(A+i,s))+1) > sp<<3) abort();
+ if (i == hp && (hp += strlen(strcpy(A+i,s))+1) > sp<<3) abort(); lwm();
  return box(ATOM,i);
 }
-L cons(L x,L y) { cell[--sp] = x; cell[--sp] = y; if (hp > sp<<3) abort(); return box(CONS,sp); }
+L cons(L x,L y) { cell[--sp] = x; cell[--sp] = y; if (hp > sp<<3) abort(); lwm(); return box(CONS,sp); }
 L car(L p) { return (T(p)&~(CONS^CLOS)) == CONS ? cell[ord(p)+1] : err; }
 L cdr(L p) { return (T(p)&~(CONS^CLOS)) == CONS ? cell[ord(p)] : err; }
 L pair(L v,L x,L e) { return cons(cons(v,x),e); }
@@ -129,5 +130,5 @@ int main() {
  printf("tinylisp");
  nil = box(NIL,0); err = atom("ERR"); tru = atom("#t"); env = pair(tru,tru,nil);
  for (i = 0; prim[i].s; ++i) env = pair(atom(prim[i].s),box(PRIM,i),env);
- while (1) { printf("\n%u>",sp-hp/8); print(eval(Read(),env)); gc(); }
+ while (1) { printf("\n%u|%u>",sp-hp/8,lo); print(eval(Read(),env)); gc(); }
 }

--- a/src/tinylisp-opt.c
+++ b/src/tinylisp-opt.c
@@ -59,7 +59,7 @@ struct { const char *s; L (*f)(L,L*); short t; } prim[] = {
 {"or",    f_or,    0},{"and",   f_and,   0},{"not", f_not, 0},{"cond",f_cond,1},{"if", f_if, 1},{"let*",f_leta,1},
 {"lambda",f_lambda,0},{"define",f_define,0},{0}};
 L eval(L x,L e) {
- L f,v,d; char evaluated;
+ L f,v,d;
  while (1) {
   if (T(x) == ATOM) return assoc(x,e);
   if (T(x) != CONS) return x;
@@ -72,17 +72,14 @@ L eval(L x,L e) {
   if (T(f) != CLOS) return err;
   v = car(car(f)); d = cdr(f);
   if (T(d) == NIL) d = env;
-  evaluated = 0;
   for(;T(v) != NIL;v = cdr(v),x = cdr(x)) {
-    if (T(x) != CONS) {
-      evaluated = 1;
-      x = eval(x, e);
-    }
-    if (T(v) == ATOM) {
-      d = pair(v, (evaluated ? x : evlis(x, e)), d);
-      break;
-    }
-    d = pair(car(v),(evaluated ? car(x) : eval(car(x),e)),d);
+    if (T(x) != CONS) { x = eval(x, e); break; }
+    if (T(v) == ATOM) { d = pair(v, evlis(x, e), d); v = nil; break; }
+    d = pair(car(v),eval(car(x),e),d);
+  }
+  for(;T(v) != NIL;v = cdr(v),x = cdr(x)) {
+    if (T(v) == ATOM) { d = pair(v, x, d); break; }
+    d = pair(car(v),car(x),d);
   }
   x = cdr(car(f)); e = d;
  }

--- a/src/tinylisp-opt.c
+++ b/src/tinylisp-opt.c
@@ -72,15 +72,9 @@ L eval(L x,L e) {
   if (T(f) != CLOS) return err;
   v = car(car(f)); d = cdr(f);
   if (T(d) == NIL) d = env;
-  for(;T(v) != NIL;v = cdr(v),x = cdr(x)) {
-    if (T(x) != CONS) { x = eval(x, e); break; }
-    if (T(v) == ATOM) { d = pair(v, evlis(x, e), d); v = nil; break; }
-    d = pair(car(v),eval(car(x),e),d);
-  }
-  for(;T(v) != NIL;v = cdr(v),x = cdr(x)) {
-    if (T(v) == ATOM) { d = pair(v, x, d); break; }
-    d = pair(car(v),car(x),d);
-  }
+  for (;T(v) == CONS && T(x) == CONS; v = cdr(v),x = cdr(x)) d = pair(car(v),eval(car(x),e),d);
+  for (x = T(x) == CONS ? evlis(x,e) : eval(x,e); T(v) == CONS; v = cdr(v),x = cdr(x)) d = pair(car(v),car(x),d);
+  if (T(v) == ATOM) d = pair(v,x,d);
   x = cdr(car(f)); e = d;
  }
 }

--- a/tests/dotcall.lisp
+++ b/tests/dotcall.lisp
@@ -1,0 +1,87 @@
+(define err? (lambda (x) (eq? x 'ERR)))
+(define pair? (lambda (x) (not (err? (cdr x)))))
+(define equal?
+    (lambda (x y)
+        (or
+            (eq? x y)
+            (and
+                (pair? x)
+                (pair? y)
+                (equal? (car x) (car y))
+                (equal? (cdr x) (cdr y))))))
+(define list (lambda args args))
+
+(cons
+ (if (equal?
+      ((lambda (x y z) (list x y z)) '(1) '(2) '(3)) '((1) (2) (3)))
+     'passed
+     'failed)
+ '(same-args))
+
+(cons
+ (if (equal?
+      ((lambda (x y) (list x y)) '(1) '(2) '(3)) '((1) (2)))
+     'passed
+     'failed)
+ '(extra-args))
+
+(cons
+ (if (equal?
+      ((lambda (x y z) (list x y z)) '(1) '(2)) '((1) (2) ERR))
+     'passed
+     'failed)
+ '(scant-args))
+
+(cons
+ (if (equal?
+      ((lambda (l)
+         ((lambda (x y z) (list x y z)) '(1) '(2) . l)) '((3)))
+      '((1) (2) (3)))
+     'passed
+     'failed)
+ '(caller-dot))
+
+(cons
+ (if (equal?
+      ((lambda (x y . z) (list x y z)) '(1) '(2) '(3))
+      '((1) (2) ((3))))
+     'passed
+     'failed)
+ '(callee-dot))
+
+(cons
+ (if (equal?
+      ((lambda (l)
+         ((lambda (x y . z) (list x y z)) '(1) '(2) . l)) '((3)))
+      '((1) (2) ((3))))
+     'passed
+     'failed)
+ '(both-dot))
+
+(cons
+ (if (equal?
+      ((lambda (l)
+         ((lambda (x . y) (list x y)) '(1) '(2) . l)) '((3)))
+      '((1) ((2) (3))))
+     'passed
+     'failed)
+ '(extra-dot))
+
+(cons
+ (if (equal?
+      ((lambda (l)
+         ((lambda (x . y) (list x y)) '(1) . l)) '((2) (3)))
+      '((1) ((2) (3))))
+     'passed
+     'failed)
+ '(scant-dot))
+
+(cons
+ (if (equal?
+      ((lambda (l)
+         ((lambda (x y . z) (list x y z)) '(1) . l)) '((2) (3)))
+      '((1) (2) ((3))))
+     'passed
+     'failed)
+ '(early-dot))
+


### PR DESCRIPTION
This PR fixes issue #17 by calling `evlis(x,e)` to evaluate all arguments once and only once before bnding them to the formal parameters.

This is the simplest fix I could think of, and I was initially worried that the `evlis` would consume unnecessary cons cells by building up a superfluous argument list, but its memory behavior appears to be good. Please feel free to check my work / make requests. There wasn't a test mechanism in place so I took a stab at a simple one.

Thanks so much for tinylisp! I've been having a ton of fun with it, and I'm looking forward to trying out your other lisps.